### PR TITLE
Adds basic tests for "WP Grade Comments"

### DIFF
--- a/cypress.dist.json
+++ b/cypress.dist.json
@@ -2,7 +2,17 @@
   "baseUrl": "http://openlabdev.test",
   "env": {
     "site": "/e2e-testing",
-    "wp_user": "admin",
-    "wp_pass": "secret"
+    "faculty": {
+      "user": "e2etestfaculty",
+      "pass": "secret"
+    },
+    "student": {
+      "user": "e2eteststudent",
+      "pass": "secret"
+    },
+    "member": {
+      "user": "e2etestmember",
+      "pass": "secret"
+    }
   }
 }

--- a/cypress.dist.json
+++ b/cypress.dist.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://openlabdev.test",
   "env": {
+    "site": "/e2e-testing",
     "wp_user": "admin",
     "wp_pass": "secret"
   }

--- a/cypress.dist.json
+++ b/cypress.dist.json
@@ -6,12 +6,12 @@
       "user": "e2etestfaculty",
       "pass": "secret"
     },
-    "student": {
-      "user": "e2eteststudent",
+    "student1": {
+      "user": "e2eteststudent1",
       "pass": "secret"
     },
-    "member": {
-      "user": "e2etestmember",
+    "student2": {
+      "user": "e2eteststudent2",
       "pass": "secret"
     }
   }

--- a/cypress/integration/grade-comments/admin.spec.js
+++ b/cypress/integration/grade-comments/admin.spec.js
@@ -13,7 +13,7 @@ describe( 'Grade comments as an admin', () => {
 		});
 
 		beforeEach( () => {
-			cy.get('.comment-list > .comment-grade').first().as('gradeComment');
+			cy.get('.comment-list > .comment-has-grade').first().as('gradeComment');
 		});
 
 		it( 'can see grade/private comments options', () => {
@@ -23,11 +23,11 @@ describe( 'Grade comments as an admin', () => {
 		});
 
 		it( 'can see grade comments', () => {
-			cy.get('.comment-list > .comment-grade').should('exist');
+			cy.get('.comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'can see private comments', () => {
-			cy.get('.comment-list > .comment-private').should('exist');
+			cy.get('.comment-list > .comment-is-private').should('exist');
 		});
 
 		it( 'has default state of hidden', () => {
@@ -65,11 +65,11 @@ describe( 'Grade comments as an admin', () => {
 		});
 
 		it( 'can see grade comments', () => {
-			cy.get('#the-comment-list > .comment-grade').should('exist');
+			cy.get('#the-comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'can see private comments', () => {
-			cy.get('#the-comment-list > .comment-private').should('exist');
+			cy.get('#the-comment-list > .comment-is-private').should('exist');
 		});
 	});
 });

--- a/cypress/integration/grade-comments/admin.spec.js
+++ b/cypress/integration/grade-comments/admin.spec.js
@@ -3,7 +3,7 @@ describe( 'Grade comments as an admin', () => {
 
 	before( () => {
 		cy.logout();
-		cy.login();
+		cy.login('faculty');
 		cy.preserveCookies();
 	});
 

--- a/cypress/integration/grade-comments/admin.spec.js
+++ b/cypress/integration/grade-comments/admin.spec.js
@@ -1,0 +1,75 @@
+describe( 'Grade comments as an admin', () => {
+	const siteUrl = Cypress.env( 'site' );
+
+	before( () => {
+		cy.logout();
+		cy.login();
+		cy.preserveCookies();
+	});
+
+	context( 'Site', () => {
+		before( () => {
+			cy.visit(`${siteUrl}/test-grade-comments/`);
+		});
+
+		beforeEach( () => {
+			cy.get('.comment-list > .comment-grade').first().as('gradeComment');
+		});
+
+		it( 'can see grade comments options', () => {
+			cy.get('#olgc-private-comment').should('exist');
+			cy.get('#olgc-add-a-grade').should('exist');
+			cy.get('#olgc-grade').should('exist');
+		});
+
+		it( 'can see grade comments', () => {
+			cy.get('.comment-list > .comment-grade').should('exist');
+		});
+
+		it( 'can see private comments', () => {
+			cy.get('.comment-list > .comment-private').should('exist');
+		});
+
+		it( 'has default state of hidden', () => {
+			cy.get('@gradeComment')
+				.find('.olgc-grade-display')
+				.should('have.class', 'olgc-grade-hidden');
+		});
+
+		it( 'can reveal grades', () => {
+			cy.get('@gradeComment')
+				.find('.olgc-show-grade')
+				.each( ( $el ) => cy.wrap($el).click() );
+
+			cy.get('@gradeComment')
+				.find('.olgc-grade-display')
+				.should('not.have.class', 'olgc-grade-hidden');
+		});
+	});
+
+	context( 'Dashboard', () => {
+		before( () => {
+			cy.visit(`${siteUrl}/wp-admin/`);
+		});
+
+		it( 'can see grade column for posts', () => {
+			cy.get('#menu-posts > a').click();
+
+			cy.get('#grade').should('exist').and('contain', 'Grade');
+		});
+
+		it( 'can see grade column for comments', () => {
+			cy.get('#menu-comments > a').click();
+
+			cy.get('#grade').should('exist').and('contain', 'Grade');
+		});
+
+		it( 'can see grade comments', () => {
+			cy.get('#the-comment-list > .comment-grade').should('exist');
+		});
+
+		it( 'can see private comments', () => {
+			cy.get('#the-comment-list > .comment-private').should('exist');
+		});
+	});
+});

--- a/cypress/integration/grade-comments/author.spec.js
+++ b/cypress/integration/grade-comments/author.spec.js
@@ -1,9 +1,9 @@
-describe( 'Grade comments as an admin', () => {
+describe( 'Grade comments as an author', () => {
 	const siteUrl = Cypress.env('site');
 
 	before( () => {
 		cy.logout();
-		cy.login('faculty');
+		cy.login('student1');
 		cy.preserveCookies();
 	});
 
@@ -13,13 +13,14 @@ describe( 'Grade comments as an admin', () => {
 		});
 
 		beforeEach( () => {
+			cy.get('.comment-list > .comment-private').first().as('privateComment');
 			cy.get('.comment-list > .comment-grade').first().as('gradeComment');
 		});
 
-		it( 'can see grade/private comments options', () => {
-			cy.get('#olgc-private-comment').should('exist');
-			cy.get('#olgc-add-a-grade').should('exist');
-			cy.get('#olgc-grade').should('exist');
+		it( 'cannot see grade/private comments options', () => {
+			cy.get('#olgc-private-comment').should('not.exist');
+			cy.get('#olgc-add-a-grade').should('not.exist');
+			cy.get('#olgc-grade').should('not.exist');
 		});
 
 		it( 'can see grade comments', () => {
@@ -44,6 +45,14 @@ describe( 'Grade comments as an admin', () => {
 			cy.get('@gradeComment')
 				.find('.olgc-grade-display')
 				.should('not.have.class', 'olgc-grade-hidden');
+		});
+
+		it( 'can leave private reply', () => {
+			cy.get('@privateComment')
+				.find('.comment-reply-link')
+				.click();
+
+			cy.get('#comment').should('have.focus');
 		});
 	});
 

--- a/cypress/integration/grade-comments/author.spec.js
+++ b/cypress/integration/grade-comments/author.spec.js
@@ -13,8 +13,8 @@ describe( 'Grade comments as an author', () => {
 		});
 
 		beforeEach( () => {
-			cy.get('.comment-list > .comment-private').first().as('privateComment');
-			cy.get('.comment-list > .comment-grade').first().as('gradeComment');
+			cy.get('.comment-list > .comment-is-private').first().as('privateComment');
+			cy.get('.comment-list > .comment-has-grade').first().as('gradeComment');
 		});
 
 		it( 'cannot see grade/private comments options', () => {
@@ -24,11 +24,11 @@ describe( 'Grade comments as an author', () => {
 		});
 
 		it( 'can see grade comments', () => {
-			cy.get('.comment-list > .comment-grade').should('exist');
+			cy.get('.comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'can see private comments', () => {
-			cy.get('.comment-list > .comment-private').should('exist');
+			cy.get('.comment-list > .comment-is-private').should('exist');
 		});
 
 		it( 'has default state of hidden', () => {
@@ -74,11 +74,11 @@ describe( 'Grade comments as an author', () => {
 		});
 
 		it( 'can see grade comments', () => {
-			cy.get('#the-comment-list > .comment-grade').should('exist');
+			cy.get('#the-comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'can see private comments', () => {
-			cy.get('#the-comment-list > .comment-private').should('exist');
+			cy.get('#the-comment-list > .comment-is-private').should('exist');
 		});
 	});
 });

--- a/cypress/integration/grade-comments/student.spec.js
+++ b/cypress/integration/grade-comments/student.spec.js
@@ -1,0 +1,55 @@
+describe( 'Grade comments as a student', () => {
+	const siteUrl = Cypress.env('site');
+
+	before( () => {
+		cy.logout();
+		cy.login('student2');
+		cy.preserveCookies();
+	});
+
+	context( 'Site', () => {
+		before( () => {
+			cy.visit(`${siteUrl}/test-grade-comments/`);
+		});
+
+		it( 'cannot see grade/private comments options', () => {
+			cy.get('#olgc-private-comment').should('not.exist');
+			cy.get('#olgc-add-a-grade').should('not.exist');
+			cy.get('#olgc-grade').should('not.exist');
+		});
+
+		it( 'can see public grade comments', () => {
+			cy.get('.comment-list > .comment-grade').should('exist');
+		});
+
+		it( 'cannot see private comments', () => {
+			cy.get('.comment-list > .comment-private').should('not.exist');
+		});
+	});
+
+	context( 'Dashboard', () => {
+		before( () => {
+			cy.visit(`${siteUrl}/wp-admin/`);
+		});
+
+		it( 'cannot see grade column for posts', () => {
+			cy.get('#menu-posts > a').click();
+
+			cy.get('#grade').should('not.exist');
+		});
+
+		it( 'cannot see grade column for comments', () => {
+			cy.get('#menu-comments > a').click();
+
+			cy.get('#grade').should('not.exist');
+		});
+
+		it( 'can see public grade comments', () => {
+			cy.get('#the-comment-list > .comment-grade').should('exist');
+		});
+
+		it( 'cannot see private comments', () => {
+			cy.get('#the-comment-list > .comment-private').should('not.exist');
+		});
+	});
+});

--- a/cypress/integration/grade-comments/student.spec.js
+++ b/cypress/integration/grade-comments/student.spec.js
@@ -19,11 +19,11 @@ describe( 'Grade comments as a student', () => {
 		});
 
 		it( 'can see public grade comments', () => {
-			cy.get('.comment-list > .comment-grade').should('exist');
+			cy.get('.comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'cannot see private comments', () => {
-			cy.get('.comment-list > .comment-private').should('not.exist');
+			cy.get('.comment-list > .comment-is-private').should('not.exist');
 		});
 	});
 
@@ -45,11 +45,11 @@ describe( 'Grade comments as a student', () => {
 		});
 
 		it( 'can see public grade comments', () => {
-			cy.get('#the-comment-list > .comment-grade').should('exist');
+			cy.get('#the-comment-list > .comment-has-grade').should('exist');
 		});
 
 		it( 'cannot see private comments', () => {
-			cy.get('#the-comment-list > .comment-private').should('not.exist');
+			cy.get('#the-comment-list > .comment-is-private').should('not.exist');
 		});
 	});
 });

--- a/cypress/integration/portfolios.spec.js
+++ b/cypress/integration/portfolios.spec.js
@@ -7,7 +7,7 @@ describe( 'Portfolios', () => {
 	};
 
 	before( () => {
-		cy.login();
+		cy.login('faculty');
 		cy.preserveCookies();
 	});
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,11 +1,13 @@
-Cypress.Commands.add('login', () => {
+Cypress.Commands.add('login', ( type ) => {
+	const account = Cypress.env( type );
+
 	cy.request({
 		url: '/wp-login.php',
 		method: 'POST',
 		form: true,
 		body: {
-			log: Cypress.env('wp_user'),
-			pwd: Cypress.env('wp_pass'),
+			log: account.user,
+			pwd: account.pass,
 			rememberme: 'forever',
 			testcookie: 1,
 		},


### PR DESCRIPTION
This is first iteration for "WP Grade Comments" tests.

Currently requires:
* livinglab/wp-grade-comments#17.
* End-to-end test setup script (WIP).